### PR TITLE
Fix header loading error handling

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,14 @@
 // js/main.js
 
 fetch('./partials/header.html')
-  .then(res => res.text())
+  .then(res => {
+    if (!res.ok) throw new Error('Failed to fetch header');
+    return res.text();
+  })
   .then(html => {
-    document.getElementById('header-placeholder').innerHTML = html;
-  });
+    const placeholder = document.getElementById('header-placeholder');
+    if (placeholder) {
+      placeholder.innerHTML = html;
+    }
+  })
+  .catch(err => console.error('Header load error:', err));


### PR DESCRIPTION
## Summary
- add error handling in the client-side fetch for the header include

## Testing
- `node -c js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_687760a6d2188322b594874feb8867fc